### PR TITLE
feat: rename plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# plugin-discount-codes
+# api-plugin-discounts-codes
 
-[![npm (scoped)](https://img.shields.io/npm/v/@reactioncommerce/plugin-discount-codes.svg)](https://www.npmjs.com/package/@reactioncommerce/plugin-discount-codes)
-[![CircleCI](https://circleci.com/gh/reactioncommerce/plugin-discount-codes.svg?style=svg)](https://circleci.com/gh/reactioncommerce/plugin-discount-codes)
+[![npm (scoped)](https://img.shields.io/npm/v/@reactioncommerce/api-plugin-discounts-codes.svg)](https://www.npmjs.com/package/@reactioncommerce/api-plugin-discounts-codes)
+[![CircleCI](https://circleci.com/gh/reactioncommerce/api-plugin-discounts-codes.svg?style=svg)](https://circleci.com/gh/reactioncommerce/api-plugin-discounts-codes)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 ## Summary

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@reactioncommerce/plugin-discount-codes",
+  "name": "@reactioncommerce/api-plugin-discounts-codes",
   "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@reactioncommerce/plugin-discount-codes",
+  "name": "@reactioncommerce/api-plugin-discounts-codes",
   "description": "Discount codes service for the Reaction API",
   "version": "0.0.0-development",
   "main": "index.js",
@@ -7,12 +7,12 @@
   "engines": {
     "node": ">=12.14.1"
   },
-  "homepage": "https://github.com/reactioncommerce/plugin-discount-codes",
-  "url": "https://github.com/reactioncommerce/plugin-discount-codes",
+  "homepage": "https://github.com/reactioncommerce/api-plugin-discounts-codes",
+  "url": "https://github.com/reactioncommerce/api-plugin-discounts-codes",
   "email": "engineering@reactioncommerce.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/reactioncommerce/plugin-discount-codes.git"
+    "url": "git+https://github.com/reactioncommerce/api-plugin-discounts-codes.git"
   },
   "author": {
     "name": "Reaction Commerce",
@@ -21,7 +21,7 @@
   },
   "license": "GPL-3.0",
   "bugs": {
-    "url": "https://github.com/reactioncommerce/plugin-discount-codes/issues"
+    "url": "https://github.com/reactioncommerce/api-plugin-discounts-codes/issues"
   },
   "sideEffects": false,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,8 @@ import startup from "./startup.js";
  */
 export default async function register(app) {
   await app.registerPlugin({
-    label: "Codes",
-    name: "discount-codes",
+    label: "Discount Codes",
+    name: "discounts-codes",
     version: app.context.appVersion,
     i18n,
     functionsByType: {


### PR DESCRIPTION
Resolves #3

Rename this plugin from `plugin-discount-codes` to `api-plugin-dissounts-codes`.

This will create a new npm package with a v1.1.0, and this new package will need to be installed in reaction core.

We also need to deprecate the existing npm package.