### PR TITLE
Add support for Edges on discountCodes query

### DIFF
--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -1,3 +1,4 @@
+import getConnectionTypeResolvers from "@reactioncommerce/api-utils/graphql/getConnectionTypeResolvers.js";
 import Mutation from "./Mutation/index.js";
 import Query from "./Query/index.js";
 import DiscountCode from "./DiscountCode/index.js";
@@ -5,5 +6,6 @@ import DiscountCode from "./DiscountCode/index.js";
 export default {
   DiscountCode,
   Mutation,
-  Query
+  Query,
+  ...getConnectionTypeResolvers("DiscountCode")
 };


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>
Resolves https://github.com/reactioncommerce/reaction/issues/6261

The `discountCodes` query isn't returning `edges` currently. This PR implements support for that.